### PR TITLE
Add Codama IDL to program binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "litesvm-token",
  "pretty-hex",
  "rand 0.8.5",
+ "solana-include-idl",
  "solana-program 1.18.26",
  "solana-sdk",
  "spl-associated-token-account 2.3.0",
@@ -2621,6 +2622,15 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "solana-include-idl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754cc8fce28c62e67593ef317d715567b4610abfce1fa9ffa1d94f6eed8ad701"
+dependencies = [
+ "flate2",
 ]
 
 [[package]]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "code-vm-program"
+description = "Purpose built VM for reduced fees on Solana"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -20,6 +22,7 @@ solana-program.workspace = true
 steel.workspace = true
 spl-token.workspace = true
 spl-associated-token-account.workspace = true
+solana-include-idl = "0.1"
 
 [dev-dependencies]
 rand = "0.8.5"
@@ -28,3 +31,6 @@ litesvm = "0.2.1"
 litesvm-token = "0.2.1"
 base64 = "0.13.0"
 pretty-hex = "0.4.1"
+
+[build-dependencies]
+solana-include-idl = { version = "0.1", features = ["shrink"] }

--- a/program/build.rs
+++ b/program/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::path::PathBuf;
+
+use solana_include_idl::compress_idl;
+
+/// Build script to compress the IDL file to a zip file when building the
+/// program.
+/// 
+/// The compressed IDL is then included in a separate ELF section on the program
+/// binary when the program is built.
+fn main() {
+    // Get the IDL path.
+    let idl_path = PathBuf::from("../idl").join("code_vm.json");
+
+    // Compress the IDL file to a zip file.
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = PathBuf::from(out_dir).join("codama.idl.zip");
+
+    compress_idl(&idl_path, &dest_path);
+}

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -3,7 +3,12 @@ mod instruction;
 use instruction::*;
 
 use code_vm_api::prelude::*;
+use solana_include_idl::{include_idl, parse::IdlType};
 use steel::*;
+
+// Include the compressed IDL in an ELF section on the program binary.
+// Ref: https://github.com/regolith-labs/ore/pull/105
+include_idl!(IdlType::Codama, concat!(env!("OUT_DIR"), "/codama.idl.zip"));
 
 pub fn process_instruction(
     program_id: &Pubkey,


### PR DESCRIPTION
This PR adds the program IDL to the ELF header section. Seems to be the least worst option. Following what the ORE guys have done in their [PR](https://github.com/regolith-labs/ore/pull/105).

Previous method required the following steps:

1. Upload the dummy anchor program (making the current on-chain program not work; temporarily)
2. Run the anchor cli to upload the IDL file — this invokes hidden instructions in the dummy program
3. Deploy the original program again, the IDL file stays (in a separate PDA)

New method chucks the IDL into the program binary.

