### PR TITLE
SUG-016 | Optimize Ed25519 Signature Verification to Reduce Compute Units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,7 @@ dependencies = [
  "num_enum 0.7.3",
  "sha2 0.10.8",
  "solana-curve25519",
+ "solana-ed25519-sha512",
  "solana-program 1.18.26",
  "solana-sdk",
  "spl-token 4.0.3",
@@ -2587,6 +2588,12 @@ dependencies = [
  "solana-program 2.0.13",
  "thiserror",
 ]
+
+[[package]]
+name = "solana-ed25519-sha512"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8320a8d89009ee71e46378ba17811357f2702b1d57a91748ed369d72cfe6c85c"
 
 [[package]]
 name = "solana-frozen-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bs58 = "0.4.0"
 bytemuck = "1.14"
 num_enum = "0.7"
 sha2 = "0.10.8"
+solana-ed25519-sha512 = { version = "0.1.2" }
 curve25519-dalek = { version = "4.1.3", default-features = false, features = ["zeroize"] }
 solana-curve25519 = "2.0.13"
 solana-program = "1.18"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,6 +15,7 @@ bs58.workspace = true
 sha2.workspace = true
 solana-curve25519.workspace = true
 curve25519-dalek.workspace = true
+solana-ed25519-sha512.workspace = true
 
 [dev-dependencies]
 solana-sdk = "1.18"


### PR DESCRIPTION
## Description

- **Problem:** The current implementation uses `sha2::Sha512`, which is resource-intensive and consumes significant Compute Units (CUs) on-chain.
- **Solution:** Replaced `sha2::Sha512` with the optimized `solana_ed25519_sha512::hash` function, specifically designed for efficient Ed25519 verification on-chain, reducing CU consumption.

## Changes Made

- **Integrated Optimized SHA-512 Hashing:**
  - Imported `solana_ed25519_sha512::hash`.
  - Replaced manual `Sha512` hashing in signature verification with the optimized `hash` function.

## Why

- **Compute Unit Savings:**
  - Benchmarks indicate a CU saving of approximately 688 CUs (~8%) over the previous implementation.

(Huge shoutout to @deanmlittle for building this crate)
