### PR TITLE
MAJ-005 | Handle Transfers to Same Account Correctly

### DIFF
--- a/program/src/opcode/transfer.rs
+++ b/program/src/opcode/transfer.rs
@@ -100,13 +100,23 @@ pub fn process_transfer(
         hash.as_ref(),
     )?;
 
-    src_vta.balance = src_vta.balance
-        .checked_sub(args.amount)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
+    if src_vta.balance < args.amount {
+        return Err(ProgramError::InsufficientFunds);
+    }
 
-    dst_vta.balance = dst_vta.balance
-        .checked_add(args.amount)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
+    // If the source and destination accounts are the same, then we don't need
+    // to do anything.
+
+    let is_same_account = src_mem == dst_mem && src_index == dst_index;
+    if !is_same_account {
+        src_vta.balance = src_vta.balance
+            .checked_sub(args.amount)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
+
+        dst_vta.balance = dst_vta.balance
+            .checked_add(args.amount)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
+    }
 
     vdn.value = vm.get_current_poh();
 


### PR DESCRIPTION
## Description

- **Problem:** Transferring funds to the same account incorrectly adjusts balances.
- **Solution:** Added a check to detect when the source and destination accounts are the same. If they are, the transfer operation is skipped to prevent altering the balance unnecessarily.

## Note

It is not possible to abuse this because the sequencer has to sign off and correctly checks against this.

## Changes Made

- **Added Same Account Check:**
  - If the source and destination are the same, skip balance adjustments.
- **Ensured Sufficient Funds:**
  - Checked that the source account has enough balance before proceeding.


