### PR TITLE
MAJ-006 | Verify System Program Ownership in check_uninitialized_pda

### DIFF
--- a/api/src/helpers.rs
+++ b/api/src/helpers.rs
@@ -74,6 +74,10 @@ pub fn check_readonly(account: &AccountInfo) -> ProgramResult {
 }
 
 pub fn check_uninitialized_pda(account: &AccountInfo, seeds: &[&[u8]], bump: u8, program_id: &Pubkey) -> ProgramResult {
+    if !account.owner.eq(&system_program::ID) {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
     account.is_empty()?.is_writable()?.has_seeds(seeds, bump, program_id)?;
     Ok(())
 }


### PR DESCRIPTION

## Description

- **Problem:** The `check_uninitialized_pda` function does not verify that the account is owned by the `system_program`. This omission could allow initialization of accounts not owned by the `system_program`, leading to potential security issues.
- **Solution:** Added a check in `check_uninitialized_pda` to confirm that the account's owner is the `system_program`. If the account is not owned by the `system_program`, the function returns an error.

## Changes Made

- **Updated `check_uninitialized_pda`:**
  - Implemented ownership verification against `system_program` ID.
  - Added error handling for accounts not owned by the `system_program`.
