### PR TITLE
Security.txt | Added initial file to build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
  "rand 0.8.5",
  "solana-program 1.18.26",
  "solana-sdk",
+ "solana-security-txt",
  "spl-associated-token-account 2.3.0",
  "spl-token 4.0.3",
  "steel",

--- a/README.md
+++ b/README.md
@@ -22,11 +22,18 @@ payments experience to millions of users at negligible cost.
 blockchain technology to deliver a seamless payments experience that is instant, 
 global, and private. 
 
+## Deployments
+
+| Network | Address |
+| --- | --- |
+| Mainnet | [vmZ1WU...5YMRTJ](https://explorer.solana.com/address/vmZ1WUq8SxjBWcaeTCvgJRZbS84R61uniFsQy5YMRTJ) |
+| Devnet | [J8FLfS...Rr3L24](https://explorer.solana.com/address/J8FLfS8rqBcQ3hH8KTfQF3zBNG3r3uaG2WqfNoRr3L24) |
+
 ## Audits
 
-| Program | Mainnet | Audited By | Audit Report | Version | Commit |
-| --- | --- | --- | --- | --- | --- |
-|[code_vm](https://github.com/code-payments/code-vm/tree/main/programs/code-vm/src) | [vmZ1WU...5YMRTJ](https://explorer.solana.com/address/vmZ1WUq8SxjBWcaeTCvgJRZbS84R61uniFsQy5YMRTJ) | OtterSec | pre-audit phase | tbd | tbd |
+| Audited By | Status | Audit Report | Version | Commit |
+| --- | --- | --- | --- | --- |
+| OtterSec | audit phase | - | tbd | tbd |
 
 ## Release Schedule
 
@@ -36,19 +43,17 @@ questions or feedback.
 
 <br>
 
-| Milestone | Status | Version | Date |
+| Milestone | Status | Code | Flipchat |
 | --- | --- | --- | --- |
-| Preview Release | Released | v0.1.0 | Aug 9th, 2024 |
-| Optimized Release | Released | v0.2.0 | Oct 24th, 2024 |
-| IDLs | [Released](https://github.com/code-payments/code-vm/blob/main/idl/code_vm.json) | v0.0.1 | Oct 30th, 2024 |
+| Preview Release | Released | - | Aug 9th, 2024 |
+| Optimized Release | Released | - | Oct 24th, 2024 |
+| Audited Release | WIP | - | - |
+| IDLs | [Released](https://github.com/code-payments/code-vm/blob/main/idl/code_vm.json) | - | Oct 30th, 2024 |
 | Indexer Service | [Released](https://github.com/code-payments/code-vm-indexer) | - | Aug 15th, 2024 |
+| Sequencer Integration | Released | - | November 25th, 2024 |
+| Mobile App Integration | Released | - | November 27th, 2024 |
 | Code VM Explorer | - | - | - |
-| Sequencer Integration | Wip | - | - |
-| Mobile App Integration | Wip | - | - |
 | Documentation | - | - | - |
-| Audit | Wip | - | - |
-| Mainnet-beta | Deployed | v0.0.1-alpha | tbd |
-
 
 ## Quick Start
 
@@ -71,6 +76,11 @@ solana-cli 1.18.9 (src:9a7dd9ca; feat:3469865029, client:SolanaLabs)
 ## Getting Help
 
 If you have any questions or need help, please reach out to us on [Discord](https://discord.gg/T8Tpj8DBFp) or [Twitter](https://twitter.com/getcode).
+
+## Community Feedback & Contributions
+While we can't guarantee that all feedback will be implemented, we are always 
+open to hearing from the community. If you have any suggestions or feedback,
+please reach out to us.
 
 ## Security and Issue Disclosures
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -21,6 +21,7 @@ solana-program.workspace = true
 steel.workspace = true
 spl-token.workspace = true
 spl-associated-token-account.workspace = true
+solana-security-txt = "1.1.1"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,7 +1,8 @@
 mod opcode;
 mod instruction;
-use instruction::*;
+mod security;
 
+use instruction::*;
 use code_vm_api::prelude::*;
 use steel::*;
 
@@ -38,3 +39,4 @@ pub fn process_instruction(
 }
 
 entrypoint!(process_instruction);
+

--- a/program/src/security.rs
+++ b/program/src/security.rs
@@ -1,0 +1,13 @@
+#[cfg(not(feature = "no-entrypoint"))]
+use {solana_security_txt::security_txt};
+
+#[cfg(not(feature = "no-entrypoint"))]
+security_txt! {
+    name: "code-vm",
+    project_url: "https://getcode.com",
+    contacts: "email:security@getcode.com,email:contact@getcode.com",
+    policy: "https://github.com/code-payments/code-vm/blob/main/SECURITY.md",
+    preferred_languages: "en",
+    source_code: "https://github.com/code-payments/code-vm",
+    auditors: "OtterSec"
+}


### PR DESCRIPTION
## Problem
The current program does not include a security.txt section as part of its binary. This is used by explorers to show who owns the program and where to report bugs. 

## Proposal
This PR adds the initial security text file using the `solana-security-txt` crate. It could be added manually, but this crate seems to be fairly standard now.

## Changes
* Included `solana-security-txt` crate
* Added initial text for the explorers to display
* Updated Readme.md to include link to dev version of program showing the security text working